### PR TITLE
Record the transfer time for NetID bans

### DIFF
--- a/banman/src/main/java/cbm/server/bot/ListBansCommand.java
+++ b/banman/src/main/java/cbm/server/bot/ListBansCommand.java
@@ -10,8 +10,10 @@ import reactor.core.publisher.Mono;
 import reactor.util.function.Tuples;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -86,9 +88,12 @@ public class ListBansCommand implements BotCommand {
     private static Stream<String> banLines(OfflineBan offlineBan, SteamID steamID, OffsetDateTime now,
                                            Map<String, Ban> currentBans) {
 
+        final OffsetDateTime enactedTime = Optional.ofNullable(offlineBan.getEnactedTime())
+                                                   .map(instant -> OffsetDateTime.ofInstant(instant, ZoneId.of("UTC")))
+                                                   .orElse(now);
         final String banLine = "```\n" + BanGenerator.banLine(steamID,
                                                               offlineBan.getDuration().toSeconds(),
-                                                              now,
+                                                              enactedTime,
                                                               offlineBan.getPlayerName(),
                                                               offlineBan.getReason()) + "\n```";
 

--- a/banman/src/main/java/cbm/server/bot/LogCommand.java
+++ b/banman/src/main/java/cbm/server/bot/LogCommand.java
@@ -3,9 +3,11 @@ package cbm.server.bot;
 import cbm.server.Bot;
 import cbm.server.SteamID;
 import cbm.server.db.BansDatabase;
+import cbm.server.model.Ban;
 import org.jetbrains.annotations.NotNull;
 import reactor.core.publisher.Mono;
 
+import java.time.Duration;
 import java.util.List;
 
 public class LogCommand implements BotCommand {
@@ -13,6 +15,7 @@ public class LogCommand implements BotCommand {
     private static final String[] DESCRIPTION = new String[]{
             "*id-or-url* - Shows player's ban history."
     };
+    private static final int SECONDS_PER_DAY = 24 * 3600;
 
     private final BansDatabase bansDatabase;
 
@@ -45,8 +48,8 @@ public class LogCommand implements BotCommand {
 
         final StringBuilder sb = new StringBuilder("**Ban history** ");
         sb.append(steamID.profileUrl()).append(":\n```diff");
-        for (var ban : banHistory) {
-            switch (ban.getAction()) {
+        for (var banLogEntry : banHistory) {
+            switch (banLogEntry.getAction()) {
                 case "add":
                     sb.append("\n+ ");
                     break;
@@ -55,14 +58,40 @@ public class LogCommand implements BotCommand {
                     sb.append("\n- ");
                     break;
             }
-            sb.append(ban.getDetectedAt()).append(": \"")
-              .append(ban.getBan().getPlayerName()).append("\" banned from ")
-              .append(ban.getBan().getEnactedTime())
-              .append(" until ").append(ban.getBan().getBannedUntil())
-              .append(" for \"").append(ban.getBan().getReason()).append("\"");
+            final Ban ban = banLogEntry.getBan();
+            sb.append(banLogEntry.getDetectedAt()).append(": \"")
+              .append(ban.getPlayerName()).append("\" banned from ")
+              .append(ban.getEnactedTime())
+              .append(" until ").append(ban.getBannedUntil())
+              .append(" (duration ");
+            append(sb, ban.getDuration());
+            sb.append(") for \"").append(ban.getReason()).append("\"");
         }
         sb.append("```");
 
         return sb.toString();
+    }
+
+    private static void append(StringBuilder sb, Duration duration) {
+        final long seconds = duration.toSeconds();
+        final long days = seconds / SECONDS_PER_DAY;
+        if (days == 0) {
+            sb.append(duration);
+            return;
+        }
+
+        final long weeksPart = days / 7;
+        final long daysPart = days % 7;
+        final long secondsPart = seconds % SECONDS_PER_DAY;
+        final Duration subDayDuration = Duration.ofSeconds(secondsPart);
+        sb.append("P");
+        if (weeksPart != 0)
+            sb.append(weeksPart).append("W");
+
+        if (daysPart != 0)
+            sb.append(daysPart).append("D");
+
+        final String s = subDayDuration.toString();
+        sb.append(s, 1, s.length());
     }
 }

--- a/banman/src/main/java/cbm/server/db/BansDatabase.java
+++ b/banman/src/main/java/cbm/server/db/BansDatabase.java
@@ -199,6 +199,7 @@ public class BansDatabase implements AutoCloseable {
 
         return new OfflineBan.Builder()
                 .setId(ban.getId())
+                .setEnactedTime(Instant.now())
                 .setDuration(Duration.ofDays(7))
                 .setPlayerName(playerName)
                 .setReason("Converted from broken NetID ban.")
@@ -371,6 +372,7 @@ public class BansDatabase implements AutoCloseable {
     private OfflineBan asOfflineBan(Entity entity) {
         return new OfflineBan.Builder()
                 .setId(getProperty(entity, "player-id"))
+                .setEnactedTime(getProperty(entity, "enacted-time"))
                 .setDuration(getProperty(entity, "duration"))
                 .setPlayerName(getProperty(entity, "player-name"))
                 .setReason(getProperty(entity, "reason"))
@@ -401,6 +403,7 @@ public class BansDatabase implements AutoCloseable {
 
     private void saveOfflineBan(OfflineBan ban, Entity entity) {
         setProperty(entity, "player-id", ban.getId());
+        setProperty(entity, "enacted-time", ban.getEnactedTime());
         setProperty(entity, "duration", ban.getDuration());
         setProperty(entity, "player-name", ban.getPlayerName());
         setProperty(entity, "reason", ban.getReason());

--- a/banman/src/main/java/cbm/server/model/OfflineBan.java
+++ b/banman/src/main/java/cbm/server/model/OfflineBan.java
@@ -1,16 +1,19 @@
 package cbm.server.model;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.StringJoiner;
 
 public class OfflineBan {
     private final String id;
+    private final Instant enactedTime;
     private final Duration duration;
     private final String playerName;
     private final String reason;
 
     private OfflineBan(Builder builder) {
         this.id = builder.id;
+        this.enactedTime = builder.enactedTime;
         this.duration = builder.duration;
         this.playerName = builder.playerName;
         this.reason = builder.reason;
@@ -18,6 +21,10 @@ public class OfflineBan {
 
     public String getId() {
         return id;
+    }
+
+    public Instant getEnactedTime() {
+        return enactedTime;
     }
 
     public Duration getDuration() {
@@ -44,6 +51,7 @@ public class OfflineBan {
 
     public static class Builder {
         private String id;
+        private Instant enactedTime;
         private Duration duration;
         private String playerName;
         private String reason;
@@ -54,6 +62,11 @@ public class OfflineBan {
 
         public Builder setId(String id) {
             this.id = id;
+            return this;
+        }
+
+        public Builder setEnactedTime(Instant enactedTime) {
+            this.enactedTime = enactedTime;
             return this;
         }
 


### PR DESCRIPTION
When converting NetID bans to offline ones it makes sense to
use the time the ban was seen as basis for the offline ban. This
is because unlike the normal offline bans, the NetID bans are
already effective.

Fixes #1 