### PR TITLE
Fix 8/long response

### DIFF
--- a/banman/src/main/java/cbm/server/Bot.java
+++ b/banman/src/main/java/cbm/server/Bot.java
@@ -6,6 +6,7 @@ import cbm.server.bot.BotCommand;
 import cbm.server.bot.HelpCommand;
 import cbm.server.bot.ListBansCommand;
 import cbm.server.bot.LogCommand;
+import cbm.server.bot.MessageComposer;
 import cbm.server.bot.PingCommand;
 import cbm.server.bot.ProfileCommand;
 import cbm.server.bot.SearchCommand;
@@ -31,6 +32,7 @@ import reactor.util.function.Tuples;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
@@ -164,8 +166,16 @@ public class Bot implements Callable<Integer> {
 
     @NotNull
     private Mono<Message> replyTo(Message message, String response) {
+        final String rs;
+        if (response.getBytes(StandardCharsets.UTF_8).length > MessageComposer.MAX_MESSAGE_LENGTH) {
+            LOGGER.error("Response message too long!", new RuntimeException());
+            rs = response.substring(0, MessageComposer.MAX_MESSAGE_LENGTH - 3) + "...";
+        } else {
+            rs = response;
+        }
+
         return message.getChannel()
-                      .flatMap(channel -> channel.createMessage(spec -> spec.setContent(response)
+                      .flatMap(channel -> channel.createMessage(spec -> spec.setContent(rs)
                                                                             .setMessageReference(message.getId())));
     }
 

--- a/banman/src/main/java/cbm/server/bot/AddBanCommand.java
+++ b/banman/src/main/java/cbm/server/bot/AddBanCommand.java
@@ -16,8 +16,8 @@ import java.time.temporal.ChronoUnit;
 public class AddBanCommand implements BotCommand {
 
     private static final String[] DESCRIPTION = new String[]{
-            "*id-or-url* *period* *reason* - Add an offline. The *reason* will automatically contain the name of the " +
-                    "admin, who's adding the ban."
+            "*id-or-url* *period* *reason* - Add an offline ban. The *reason* will automatically contain the name of " +
+                    "the admin, who's adding the ban."
     };
 
     private final BansDatabase bansDatabase;

--- a/banman/src/main/java/cbm/server/bot/AddBanCommand.java
+++ b/banman/src/main/java/cbm/server/bot/AddBanCommand.java
@@ -6,6 +6,7 @@ import cbm.server.model.OfflineBan;
 import discord4j.core.object.entity.Message;
 import discord4j.core.object.entity.User;
 import org.jetbrains.annotations.NotNull;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.OffsetDateTime;
@@ -36,7 +37,7 @@ public class AddBanCommand implements BotCommand {
     }
 
     @Override
-    public @NotNull Mono<String> execute(String params, Message message) {
+    public @NotNull Flux<String> execute(String params, Message message) {
         try {
             final String[] split = params.split("\\s+", 3);
             if (split.length != 3)
@@ -52,19 +53,19 @@ public class AddBanCommand implements BotCommand {
                              .orElse("");
 
             return Bot.resolveSteamID(split[0])
-                      .flatMap(id -> Bot.getPlayerName(id)
-                                        .switchIfEmpty(Mono.just("player_" + id.steamID64()))
-                                        .map(name -> new OfflineBan.Builder()
-                                                .setId(Long.toString(id.steamID64()))
-                                                .setDurationSeconds(seconds)
-                                                .setPlayerName(name)
-                                                .setReason(reason)
-                                                .build())
-                                        .flatMap(bansDatabase::addOfflineBan)
-                                        .map(added -> added ? "Ban successfully saved"
-                                                            : "There is an existing offline ban for this player"));
+                      .flatMapMany(id -> Bot.getPlayerName(id)
+                                            .switchIfEmpty(Mono.just("player_" + id.steamID64()))
+                                            .map(name -> new OfflineBan.Builder()
+                                                                 .setId(Long.toString(id.steamID64()))
+                                                                 .setDurationSeconds(seconds)
+                                                                 .setPlayerName(name)
+                                                                 .setReason(reason)
+                                                                 .build())
+                                            .flatMap(bansDatabase::addOfflineBan)
+                                            .map(added -> added ? "Ban successfully saved"
+                                                                : "There is an existing offline ban for this player"));
         } catch (RuntimeException e) {
-            return Mono.error(e);
+            return Flux.error(e);
         }
     }
 }

--- a/banman/src/main/java/cbm/server/bot/BotCommand.java
+++ b/banman/src/main/java/cbm/server/bot/BotCommand.java
@@ -2,6 +2,7 @@ package cbm.server.bot;
 
 import discord4j.core.object.entity.Message;
 import org.jetbrains.annotations.NotNull;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface BotCommand {
@@ -14,7 +15,7 @@ public interface BotCommand {
         return Mono.just(params);
     }
 
-    default @NotNull Mono<String> execute(String params, Message message) {
-        return execute(params);
+    default @NotNull Flux<String> execute(String params, Message message) {
+        return execute(params).flux();
     }
 }

--- a/banman/src/main/java/cbm/server/bot/HelpCommand.java
+++ b/banman/src/main/java/cbm/server/bot/HelpCommand.java
@@ -1,7 +1,8 @@
 package cbm.server.bot;
 
+import discord4j.core.object.entity.Message;
 import org.jetbrains.annotations.NotNull;
-import reactor.core.publisher.Mono;
+import reactor.core.publisher.Flux;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -64,7 +65,7 @@ public class HelpCommand implements BotCommand {
     }
 
     @Override
-    public @NotNull Mono<String> execute(String params) {
+    public @NotNull Flux<String> execute(String params, Message message) {
         final String cmd = params.trim().toLowerCase();
         final String u = usage.get(cmd);
         final Stream<String> commands;
@@ -73,7 +74,8 @@ public class HelpCommand implements BotCommand {
         else
             commands = usage.values().stream();
 
-        return Mono.just(Stream.concat(commands, Stream.of(FOOTER))
-                               .collect(Collectors.joining("\n", "**Usage**:", "")));
+        final MessageComposer composer = new MessageComposer.Builder().build();
+        return Flux.fromIterable(composer.compose(Stream.concat(commands, Stream.of(FOOTER))
+                                                        .collect(Collectors.toList())));
     }
 }

--- a/banman/src/main/java/cbm/server/bot/ListBansCommand.java
+++ b/banman/src/main/java/cbm/server/bot/ListBansCommand.java
@@ -82,14 +82,14 @@ public class ListBansCommand implements BotCommand {
 
         final MessageComposer composer = new MessageComposer.Builder().build();
 
-        final List<String> collect1 =
+        final List<String> banInfos =
                 offlineBans.stream()
                            .map(b -> Tuples.of(b, SteamID.steamID(b.getId())))
                            .filter(t -> t.getT2().isPresent())
                            .map(t -> banLines(t.getT1(), t.getT2().get(), now, currentBans))
                            .collect(Collectors.toList());
 
-        return composer.compose(collect1);
+        return composer.compose(banInfos);
     }
 
     private static String banLines(OfflineBan offlineBan, SteamID steamID, OffsetDateTime now,

--- a/banman/src/main/java/cbm/server/bot/MessageComposer.java
+++ b/banman/src/main/java/cbm/server/bot/MessageComposer.java
@@ -2,6 +2,7 @@ package cbm.server.bot;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -41,6 +42,10 @@ public class MessageComposer {
         this.footerLen = this.footer.getBytes(StandardCharsets.UTF_8).length;
         this.prefixLen = this.prefix.getBytes(StandardCharsets.UTF_8).length;
         this.suffixLen = this.suffix.getBytes(StandardCharsets.UTF_8).length;
+    }
+
+    public List<String> compose(String... results) {
+        return compose(Arrays.asList(results));
     }
 
     public List<String> compose(List<String> results) {

--- a/banman/src/main/java/cbm/server/bot/MessageComposer.java
+++ b/banman/src/main/java/cbm/server/bot/MessageComposer.java
@@ -1,0 +1,103 @@
+package cbm.server.bot;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Compose messages in the following form:
+ * <pre>
+ *     header\n
+ *     prefix\n
+ *     results...\n
+ *     suffix\n
+ *     ...
+ *     prefix\n
+ *     results...\n
+ *     suffix\n
+ *     footer\n
+ * </pre>
+ * where each message is not longer than {@value MAX_MESSAGE_LENGTH} bytes.
+ */
+public class MessageComposer {
+    public static final int MAX_MESSAGE_LENGTH = 2000;
+
+    private final String header;
+    private final String footer;
+    private final String prefix;
+    private final String suffix;
+    private final int headerLen;
+    private final int footerLen;
+    private final int prefixLen;
+    private final int suffixLen;
+
+    private MessageComposer(Builder builder) {
+        this.header = Optional.ofNullable(builder.header).orElse("");
+        this.footer = Optional.ofNullable(builder.footer).orElse("");
+        this.prefix = Optional.ofNullable(builder.prefix).orElse("");
+        this.suffix = Optional.ofNullable(builder.suffix).orElse("");
+        this.headerLen = this.header.getBytes(StandardCharsets.UTF_8).length;
+        this.footerLen = this.footer.getBytes(StandardCharsets.UTF_8).length;
+        this.prefixLen = this.prefix.getBytes(StandardCharsets.UTF_8).length;
+        this.suffixLen = this.suffix.getBytes(StandardCharsets.UTF_8).length;
+    }
+
+    public List<String> compose(List<String> results) {
+        StringBuilder sb = new StringBuilder(header).append('\n').append(prefix).append('\n');
+        int currentLen = headerLen + prefixLen + 2;
+
+        final List<String> responses = new ArrayList<>();
+        final int count = results.size();
+        for (int i = 0; i < count; i++) {
+            final String info = results.get(i);
+            final int infoLen = info.getBytes(StandardCharsets.UTF_8).length + 1;
+            final int closeLen = suffixLen + (i == count - 1 ? footerLen : 0);
+            if (currentLen + infoLen + closeLen >= MAX_MESSAGE_LENGTH) {
+                sb.append(suffix).append('\n');
+                responses.add(sb.toString());
+                sb = new StringBuilder(prefix).append('\n');
+                currentLen = prefixLen;
+            }
+            sb.append(info).append('\n');
+            currentLen += infoLen;
+        }
+
+        sb.append(suffix).append('\n').append(footer);
+        responses.add(sb.toString());
+
+        return responses;
+    }
+
+    @SuppressWarnings("UnusedReturnValue")
+    public static class Builder {
+        private String header;
+        private String footer;
+        private String prefix;
+        private String suffix;
+
+        public MessageComposer build() {
+            return new MessageComposer(this);
+        }
+
+        public Builder setHeader(String header) {
+            this.header = header;
+            return this;
+        }
+
+        public Builder setFooter(String footer) {
+            this.footer = footer;
+            return this;
+        }
+
+        public Builder setPrefix(String prefix) {
+            this.prefix = prefix;
+            return this;
+        }
+
+        public Builder setSuffix(String suffix) {
+            this.suffix = suffix;
+            return this;
+        }
+    }
+}

--- a/banman/src/main/java/cbm/server/bot/RemoveBanCommand.java
+++ b/banman/src/main/java/cbm/server/bot/RemoveBanCommand.java
@@ -32,7 +32,7 @@ public class RemoveBanCommand implements BotCommand {
         final String id = params.strip();
         return Bot.resolveSteamID(id)
                   .flatMap(bansDatabase::removeOfflineBan)
-                  .map(removed -> removed ? "Offline ban removed"
-                                          : "Couldn't find an offline ban for: " + id);
+                  .map(removed -> removed ? "*Offline ban removed*"
+                                          : "*Couldn't find an offline ban for: *" + id);
     }
 }


### PR DESCRIPTION
Handle response messages, which are longer than 2000 bytes.

The commands that may produce them were converted so they split them into multiple messages. The `Bot` class logs and truncates longer messages as a fallback.
